### PR TITLE
ETR-3697: Upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: tag
 
 runs:
-  using: node20
+  using: node24
   main: action.js
 
 inputs:


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node.js 20, with forced migration to Node.js 24 starting **June 2, 2026** and full removal on **September 16, 2026**.

This PR updates `action.yml` to use `node24` as the action runtime.

## Why this is safe

The action bundles its dependencies directly in `node_modules/` with no compiled/transpiled build step. The runtime code (`action.js`) uses only:
- `@actions/core`
- `@actions/github`
- `@octokit/core`, `@octokit/plugin-retry`, `@octokit/plugin-throttling`
- `semver`

None of these have Node.js 24 compatibility issues. This is a one-line metadata change.

## After merge

The release workflow will automatically create a new tag (next continuous version after v19) when this merges to master, since `action.yml` is a trigger path.

Downstream repos using `zendesk/compute-tag` (e.g. `zendesk/support_amis`) should then pin to the new tag.

## References

- ETR-3697: https://zendesk.atlassian.net/browse/ETR-3697
- GHA deprecation notice: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/